### PR TITLE
fix: add pnpm compatibility by using root option in sendFile

### DIFF
--- a/src/api/dashboard.controller.ts
+++ b/src/api/dashboard.controller.ts
@@ -35,7 +35,9 @@ export class DashboardController {
 
     const indexPath = join(this.dashboardPath, 'index.html');
     if (existsSync(indexPath)) {
-      res.sendFile(indexPath);
+      res.sendFile('index.html', {
+        root: this.dashboardPath
+      });
     } else {
       res.status(404).json({ error: 'Dashboard not found' });
     }
@@ -45,7 +47,9 @@ export class DashboardController {
   serveAssets(@Param('filename') filename: string, @Res() res: Response) {
     const assetPath = join(this.dashboardPath, 'assets', filename);
     if (existsSync(assetPath)) {
-      res.sendFile(assetPath);
+      res.sendFile(filename, {
+        root: join(this.dashboardPath, 'assets')
+      });
     } else {
       res.status(404).json({ error: 'Asset not found' });
     }
@@ -56,7 +60,9 @@ export class DashboardController {
   serveStaticFile(@Param('filename') filename: string, @Res() res: Response) {
     const filePath = join(this.dashboardPath, `${filename}.svg`);
     if (existsSync(filePath)) {
-      res.sendFile(filePath);
+      res.sendFile(`${filename}.svg`, {
+        root: this.dashboardPath
+      });
     } else {
       res.status(404).json({ error: 'File not found' });
     }
@@ -262,7 +268,9 @@ export class DashboardController {
   private serveIndexHtml(res: Response): void {
     const indexPath = join(this.dashboardPath, 'index.html');
     if (existsSync(indexPath)) {
-      res.sendFile(indexPath);
+      res.sendFile('index.html', {
+        root: this.dashboardPath
+      });
     } else {
       res.status(404).json({ error: 'Dashboard not found' });
     }


### PR DESCRIPTION
## Summary
Fixes dashboard serving when NestLens is installed via pnpm by specifying the `root` option in all `res.sendFile()` calls.

## Problem
When installed with pnpm, the dashboard was returning a 500 "Not Found" error. This occurred because pnpm uses a unique nested symlink structure in `node_modules/.pnpm/`, and Express's `sendFile()` was unable to resolve files through multiple layers of symlinks when called with absolute paths directly.

## Solution
Changed all `sendFile()` calls from:
```typescript
res.sendFile(absolutePath);
```

to:
```typescript
res.sendFile(relativePath, { root: absoluteRoot });
```

Express internally applies additional path normalization and symlink resolution when the `root` option is provided, which properly handles pnpm's nested structure.

## Changes
- Updated `serveDashboard()` to use `{ root: this.dashboardPath }`
- Updated `serveAssets()` to use `{ root: join(this.dashboardPath, 'assets') }`
- Updated `serveStaticFile()` to use `{ root: this.dashboardPath }`
- Updated `serveIndexHtml()` to use `{ root: this.dashboardPath }`

## Technical Details

### Why `root` option works

When Express `sendFile()` receives the `root` option, it:
1. Normalizes the path using `path.normalize()`
2. Resolves symlinks more aggressively
3. Applies security validations that are paradoxically more compatible with complex symlink structures

Without `root`, Express assumes the path is already fully resolved and uses `fs.stat()` directly, which can fail with pnpm's nested symlinks.

## Testing
- ✅ Tested with `npm pack` + `npm install`
- ✅ Tested with `pnpm pack` + `pnpm install` 
- ✅ Dashboard loads correctly on `/nestlens`
- ✅ All assets (JS, CSS, SVG) load successfully
- ✅ No breaking changes for npm users

## Performance Impact
None. The `root` option is the intended way to use `sendFile()` according to Express documentation and provides the same or better performance as absolute paths.

## Breaking Changes
None. This is a backward-compatible fix.

## Related Issues
[Issue #1](https://github.com/mogretici/nestlens/issues/1)